### PR TITLE
feat: add prefer cdn url config

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,15 @@ So using the `dev` channel would look like this:
 
 For more info on the different versions see the [documentation](https://www.tinymce.com/docs/get-started-cloud/editor-plugin-version/#devtestingandstablereleases).
 
+### Auto-loading from self-defined TinyMCE Cloud
+
+If you don't like the official TinyMCE Cloud, want to use prefer cloud url, you can add `cdn-url` for the component like this:
+
+```js
+<!-- https://cdn.bootcss.com is your prefer cdn url -->
+<editor cnd-url='https://cdn.bootcss.com' :init="{/* your settings */}>"</editor>
+```
+
 ### Loading TinyMCE by yourself
 
 To opt out of using TinyMCE cloud you have to make TinyMCE globally available yourself. This can be done either by hosting the `tinymce.min.js` file by youself and adding a script tag to you HTML or, if you are using a module loader, installing TinyMCE with npm. For info on how to get TinyMCE working with module loaders check out [this page in the documentation](https://www.tinymce.com/docs/advanced/usage-with-module-loaders/).

--- a/src/components/Editor.ts
+++ b/src/components/Editor.ts
@@ -81,7 +81,8 @@ export const Editor: ThisTypedComponentOptionsWithRecordProps<Vue, {}, {}, {}, I
       const doc = this.element.ownerDocument;
       const channel = this.$props.cloudChannel ? this.$props.cloudChannel : 'stable';
       const apiKey = this.$props.apiKey ? this.$props.apiKey : '';
-      const url = `https://cloud.tinymce.com/${channel}/tinymce.min.js?apiKey=${apiKey}`;
+      const cdnUrl = this.$props.cdnUrl ? this.$props.cdnUrl : `https://cloud.tinymce.com/${channel}`;
+      const url = `${cdnUrl}/${channel}/tinymce.min.js?apiKey=${apiKey}`;
 
       ScriptLoader.load(scriptState, doc, url, initialise(this));
     }

--- a/src/components/EditorPropTypes.ts
+++ b/src/components/EditorPropTypes.ts
@@ -20,6 +20,7 @@ export interface IPropTypes {
   tagName: string;
   toolbar: string[] | string;
   value: string;
+  cdnUrl: string;
 }
 
 export const editorProps: CopyProps<IPropTypes> = {
@@ -44,5 +45,6 @@ export const editorProps: CopyProps<IPropTypes> = {
   plugins: [String, Array],
   tagName: String,
   toolbar: [String, Array],
-  value: String
+  value: String,
+  cdnUrl: String
 };


### PR DESCRIPTION
Because in China access domain `https://cloud.tinymce.com` very slow, and I don't want to add a script tag to my HTML. Then I have to change the cdn url for `tinymce` static files by adding `cdn-url` props.

Then we can use like this:

```html
<!-- https://cdn.bootcss.com is your prefer cdn url -->
<editor cnd-url='https://cdn.bootcss.com' :init="{/* your settings */}>"</editor>
```