### PR TITLE
Fix bug when changing the model several times in a row

### DIFF
--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -95,6 +95,7 @@ export const bindModelHandlers = (ctx: IEditor, editor: any) => {
   ctx.$watch('value', (val: string, prevVal: string) => {
     if (editor && typeof val === 'string' && val !== currentContent && val !== prevVal) {
       editor.setContent(val);
+      currentContent = val;
     }
   });
 


### PR DESCRIPTION
Hello @fyrkant , here is a bugfix for the following case:

```
<tinymce id="comment_field" v-model="text" />

<a @click.prevent="text = '<p>first value</p>'">1st step: click this</a>
<!-- second step: change the content of the editor to remove final "e" and put it back -->
<a @click.prevent="text = '<p>second value</p>'">3rd step: click this</a>
<a @click.prevent="text = '<p>first value</p>'">4nd step: click this</a>
```

After doing the 4 steps, this displays: "second value" instead of "first value".

Explanation: when we change the value programmatically, the tinymce-vue plugin doesn't save the new value. And on the next programmatic change, if the new value is the same as the saved value, the editor doesn't update the content.