### PR TITLE
INT-2159: Compare content using the current outputFormat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.2.2 (TBD)
+* Fixed v-model `outputFormat` resetting the editor content on every change
+
 ## 3.2.1 (2020-04-30)
 * Upgraded jquery in dev dependencies in response to security alert.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.2.2 (TBD)
+## 3.2.2 (2020-05-22)
 * Fixed v-model `outputFormat` resetting the editor content on every change
 
 ## 3.2.1 (2020-04-30)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinymce/tinymce-vue",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "Official TinyMCE Vue Component",
   "private": false,
   "repository": {

--- a/src/main/ts/Utils.ts
+++ b/src/main/ts/Utils.ts
@@ -95,7 +95,7 @@ const bindModelHandlers = (ctx: IEditor, editor: any) => {
   const normalizedEvents = Array.isArray(modelEvents) ? modelEvents.join(' ') : modelEvents;
 
   ctx.$watch('value', (val: string, prevVal: string) => {
-    if (editor && typeof val === 'string' && val !== prevVal && val !== editor.getContent()) {
+    if (editor && typeof val === 'string' && val !== prevVal && val !== editor.getContent({ format: ctx.$props.outputFormat })) {
       editor.setContent(val);
     }
   });


### PR DESCRIPTION
The wrapper is comparing the content of the Editor ignoring the current `outputFormat` resulting in the caret jumping back to the beginning of the document after every stroke

Fixes #147 