### PR TITLE
Lowercase event binding so inline html templates are handled correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.2.4 (TBA)
+* Fixed handling of inline template event bindings
+
 ## 3.2.3 (2020-09-16)
 * Update dependencies
 * Changed `keyup` to `input` for the events triggering sending out content to `v-model`.

--- a/src/main/ts/Utils.ts
+++ b/src/main/ts/Utils.ts
@@ -73,7 +73,7 @@ const validEvents = [
   'onVisualAid'
 ];
 
-const isValidKey = (key: string) => validEvents.indexOf(key) !== -1;
+const isValidKey = (key: string) => validEvents.map(event => event.toLowerCase()).indexOf(key.toLowerCase()) !== -1;
 
 const bindHandlers = (initEvent: Event, listeners: any, editor: any): void => {
   Object.keys(listeners)


### PR DESCRIPTION
As mentioned in issue #178 inline HTML templates _always_ have events lowercased.

I could not figure out how to write a storybook for this as it requires inline HTML templates. 