### PR TITLE
fix: Fix the issue of editor not being initialized completely.

### DIFF
--- a/src/main/ts/components/Editor.ts
+++ b/src/main/ts/components/Editor.ts
@@ -101,12 +101,12 @@ export const Editor: ThisTypedComponentOptionsWithRecordProps<Vue, {}, {}, {}, I
     }
   },
   beforeDestroy() {
-    if (getTinymce() !== null) {
+    if (getTinymce() !== null && this.editor) {
       getTinymce().remove(this.editor);
     }
   },
   deactivated() {
-    if (!this.inlineEditor) {
+    if (!this.inlineEditor && this.editor) {
       this.cache = this.editor.getContent();
       getTinymce()?.remove(this.editor);
     }


### PR DESCRIPTION
When the editor is not initialized completely, manually destroying the keep-alive page will destroy all editors.