### PR TITLE
INT-3302_3: Fix storybook deployment hanging in CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ mixedBeehiveFlow(
     stage("update storybook") {
       def status = beehiveFlowStatus()
       if (status.branchState == 'releaseReady' && status.isLatest) {
-        sshagent (credentials: ['3e856116-029e-4c8d-b57d-593b2fba3cb2']) {
+        tinyGit.withGitHubSSHCredentials {
           exec('yarn storybook-to-ghpages')
         }
       } else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinymce/tinymce-vue",
-  "version": "6.0.0",
+  "version": "6.0.0-rc",
   "description": "Official TinyMCE Vue 3 Component",
   "private": false,
   "repository": {


### PR DESCRIPTION
Ticket: [INT-3302](https://ephocks.atlassian.net/browse/INT-3302)

Changes:
- Use `tinyGit.withGitHubSSHCredentials` instead, which is what's used in tinymce-react & tinymce-angular Jenkinsfiles
- Put back `-rc` in package version

[INT-3302]: https://ephocks.atlassian.net/browse/INT-3302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ