### PR TITLE
Hotfix: Added explicit build step before publishing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,5 +24,9 @@ mixedBeehiveFlow(
         echo "Skipping as is not latest release"
       }
     }
+  },
+  preparePublish:{
+    yarnInstall()
+    sh "yarn build"
   }
 )

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,6 +2,7 @@
 @Library('waluigi@release/7') _
 
 mixedBeehiveFlow(
+  container: [ resourceRequestMemory: '3Gi', resourceLimitMemory: '3Gi' ],
   testPrefix: 'Tiny-Vue',
   testDirs: [ "src/test/ts/atomic", "src/test/ts/browser" ],
   platforms: [


### PR DESCRIPTION
Now that `mixedBeehiveFlow` is used in CI instead of `beehiveFlowBuild`, there's no default build step. So this just adds a build step before publishing, as well as increasing the base container resources.