### PR TITLE
INT-3324: move tinymce to be an optional peer dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+- Moved tinymce dependency to be a optional peer dependency. #INT-3324
+
 ## 6.0.0 - 2024-06-05
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinymce/tinymce-vue",
-  "version": "6.0.2-rc",
+  "version": "7.0.2-rc",
   "description": "Official TinyMCE Vue 3 Component",
   "private": false,
   "repository": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,13 @@
     "LICENSE.txt"
   ],
   "peerDependencies": {
+    "tinymce": "^7.0.0 || ^6.0.0 || ^5.5.1",
     "vue": "^3.0.0"
+  },
+  "peerDependenciesMeta": {
+    "tinymce": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@babel/core": "^7.20.2",
@@ -69,6 +75,7 @@
     "rollup-plugin-node-resolve": "^5.2.0",
     "rollup-plugin-typescript2": "^0.34.1",
     "rollup-plugin-uglify": "^6.0.0",
+    "tinymce": "^7",
     "tinymce-4": "npm:tinymce@^4",
     "tinymce-5": "npm:tinymce@^5",
     "tinymce-6": "npm:tinymce@^6",
@@ -84,8 +91,5 @@
     "vue-router": "^4.3.2",
     "vue-template-compiler": "^2.7.16",
     "webpack": "^5.75.0"
-  },
-  "dependencies": {
-    "tinymce": "^7.0.0 || ^6.0.0 || ^5.5.1"
   }
 }

--- a/src/main/ts/Utils.ts
+++ b/src/main/ts/Utils.ts
@@ -8,7 +8,7 @@
 
 import { Ref, watch, SetupContext } from 'vue';
 import { IPropTypes } from './components/EditorPropTypes';
-import { Editor as TinyMCEEditor, EditorEvent } from 'tinymce';
+import type { Editor as TinyMCEEditor, EditorEvent } from 'tinymce';
 
 const validEvents = [
   'onActivate',

--- a/src/main/ts/components/Editor.ts
+++ b/src/main/ts/components/Editor.ts
@@ -11,7 +11,7 @@ import { getTinymce } from '../TinyMCE';
 import { isTextarea, mergePlugins, uuid, isNullOrUndefined, initEditor } from '../Utils';
 import { editorProps, IPropTypes } from './EditorPropTypes';
 import { h, defineComponent, onMounted, ref, Ref, toRefs, nextTick, watch, onBeforeUnmount, onActivated, onDeactivated } from 'vue';
-import { Editor as TinyMCEEditor, EditorEvent, TinyMCE } from 'tinymce';
+import type { Editor as TinyMCEEditor, EditorEvent, TinyMCE } from 'tinymce';
 
 type EditorOptions = Parameters<TinyMCE['init']>[0];
 

--- a/src/main/ts/components/EditorPropTypes.ts
+++ b/src/main/ts/components/EditorPropTypes.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-import { TinyMCE } from 'tinymce';
+import type { TinyMCE } from 'tinymce';
 
 type EditorOptions = Parameters<TinyMCE['init']>[0];
 

--- a/src/stories/Editor.stories.tsx
+++ b/src/stories/Editor.stories.tsx
@@ -3,7 +3,7 @@ import { onBeforeMount, ref } from 'vue';
 import { ScriptLoader } from '../main/ts/ScriptLoader';
 
 import { Editor } from '../main/ts/components/Editor';
-import { Editor as TinyMCEEditor, EditorEvent } from 'tinymce';
+import type { Editor as TinyMCEEditor, EditorEvent } from 'tinymce';
 
 const apiKey = 'qagffr3pkuv17a8on1afax661irst1hbr4e6tbv888sz91jc';
 const content = `

--- a/yarn.lock
+++ b/yarn.lock
@@ -15341,10 +15341,10 @@ tiny-emitter@^2.0.0:
   resolved "https://registry.npmjs.org/tinymce/-/tinymce-7.0.1.tgz"
   integrity sha512-0a7DJnhniBx2psRuKcVQ9g4hujN6PAR4fPS0NSF1T1luH1RBDZVVEn2pGND6Ly+AW1lUm/cHOHjsasqBelMhbw==
 
-"tinymce@^7.0.0 || ^6.0.0 || ^5.5.1":
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/tinymce/-/tinymce-7.1.1.tgz#63cd62c0288bdbddb854b3565387c8d7dec14be4"
-  integrity sha512-QQJKsEiM+jUfrlxNivuVUiv1jsHv4a27rub4oqajtsYQ4mFukN3hkWQrZnzVNtnPOIUsOGU2Ycem0DnEU/JKcA==
+tinymce@^7:
+  version "7.2.1"
+  resolved "https://registry.yarnpkg.com/tinymce/-/tinymce-7.2.1.tgz#9b4f6b5a0fa647e2953c174ac69aa47483683332"
+  integrity sha512-ADd1cvdIuq6NWyii0ZOZRuu+9sHIdQfcRNWBcBps2K8vy7OjlRkX6iw7zz1WlL9kY4z4L1DvIP+xOrVX/46aHA==
 
 tmp@^0.2.1:
   version "0.2.1"


### PR DESCRIPTION
[INT-3324](https://ephocks.atlassian.net/browse/INT-3324)

Changes:
- The `tinymce` package is now an optional peer dependency.
- Imports of `tinymce` now use `import type ...` to help prevent accidental usage of tinymce JS code through a direct import in this way.

[INT-3324]: https://ephocks.atlassian.net/browse/INT-3324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ