### PR TITLE
Use license key

### DIFF
--- a/src/main/ts/components/Editor.ts
+++ b/src/main/ts/components/Editor.ts
@@ -57,6 +57,7 @@ export const Editor = defineComponent({
         plugins: mergePlugins(conf.plugins, props.plugins),
         toolbar: props.toolbar || (conf.toolbar),
         inline: inlineEditor,
+        license_key: props.licenseKey,
         setup: (editor: TinyMCEEditor) => {
           vueEditor = editor;
           editor.on('init', (e: EditorEvent<any>) => initEditor(e, props, ctx, editor, modelValue, content));


### PR DESCRIPTION
Update to pass the license key from the component to the TinyMCE instance to avoid console warnings when using the self hosted scripts.