### PR TITLE
Fix headless test failure on CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 
 mixedBeehiveFlow(
   container: [ resourceRequestMemory: '3Gi', resourceLimitMemory: '3Gi' ],
-  testContainer: [ selenium: [ image: "selenium/standalone-chrome:127.0" ] ],
+  headlessContainer: [ selenium: [ image: "selenium/standalone-chrome:127.0" ] ],
   testPrefix: 'Tiny-Vue',
   testDirs: [ "src/test/ts/atomic", "src/test/ts/browser" ],
   platforms: [


### PR DESCRIPTION
**Description of changes**
- Renamed `testContainer` to `headlessContainer` to match the expected arg of Jenkins CI pipeline library