### PR TITLE
Fix editor going blank when it is moved in the DOM (modals, Vue re-ordering) (#131, #230)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+- Fixed the editor turning blank and unresponsive after being moved in the DOM, which happens when it is used inside a modal or dialog that relocates its content, or when Vue re-orders the surrounding elements. The editor is now re-created automatically and keeps its content. #131 #230
+
 ## 6.3.0 - 2025-07-31
 
 ### Changed

--- a/src/demo/Demo.vue
+++ b/src/demo/Demo.vue
@@ -6,6 +6,7 @@
       <router-link :class="{ active: $route.path==='/inline'}" to="/inline">Inline Editor</router-link>
       <router-link :class="{ active: $route.path==='/controlled'}" to="/controlled">Controlled component</router-link>
       <router-link :class="{ active: $route.path==='/keepalive'}" to="/keepalive">Keep-alive</router-link>
+      <router-link :class="{ active: $route.path==='/modal'}" to="/modal">Modal</router-link>
       <router-link :class="{ active: $route.path==='/refreshable'}" to="/refreshable">Rerender</router-link>
       <router-link :class="{ active: $route.path==='/tagged'}" to="/tagged">Tag Change</router-link>
       <router-link :class="{ active: $route.path === '/get-editor' }" to="/get-editor">getEditor</router-link>

--- a/src/demo/demo.ts
+++ b/src/demo/demo.ts
@@ -7,6 +7,7 @@ import Iframe from '/views/Iframe.vue';
 import Inline from '/views/Inline.vue';
 import Controlled from '/views/Controlled.vue';
 import Keepalive from '/views/KeepAlive.vue';
+import Modal from '/views/Modal.vue';
 import Refreshable from '/views/Refreshable.vue';
 import Tagged from '/views/Tagged.vue';
 import GetEditor from '/views/GetEditor.vue';
@@ -36,6 +37,11 @@ const routes = [
     path: '/keepalive',
     name: 'Keepalive',
     component: Keepalive
+  },
+  {
+    path: '/modal',
+    name: 'Modal',
+    component: Modal
   },
   {
     path: '/refreshable',

--- a/src/demo/views/Modal.vue
+++ b/src/demo/views/Modal.vue
@@ -1,0 +1,89 @@
+<template>
+  <div>
+    <h2>Editor inside a modal</h2>
+    <p>
+      Modal and dialog libraries (Bootstrap-Vue, Vuetify, &hellip;) move their
+      content to another part of the document when they open. That detaches and
+      re-attaches the editor's <code>&lt;iframe&gt;</code>, which the browser blanks,
+      historically leaving the editor in an unresponsive &ldquo;zombie&rdquo; state
+      (<a href="https://github.com/tinymce/tinymce-vue/issues/131" target="_blank" rel="noopener">#131</a>).
+      The component now detects the re-attach and transparently re-initializes while
+      preserving content. This demo reproduces the exact condition with a
+      <code>&lt;Teleport&gt;</code>-based modal &mdash; open and close it repeatedly and
+      the editor keeps working.
+    </p>
+    <button @click="open = true">Open modal</button>
+
+    <teleport to="body" :disabled="!open">
+      <div v-show="open" class="demo-modal-backdrop" @click.self="open = false">
+        <div class="demo-modal">
+          <header class="demo-modal-header">
+            <strong>Compose message</strong>
+            <button @click="open = false">Close</button>
+          </header>
+          <editor :api-key="apiKey" :init="conf" v-model="content" />
+          <p class="demo-modal-preview"><em>Live v-model:</em> {{ content }}</p>
+        </div>
+      </div>
+    </teleport>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref } from "vue";
+import Editor from "/@/main/ts/index";
+
+const apiKey = "qagffr3pkuv17a8on1afax661irst1hbr4e6tbv888sz91jc";
+
+export default defineComponent({
+  name: "Modal",
+  components: {
+    Editor
+  },
+  setup() {
+    const open = ref(false);
+    const content = ref("<p>Edit me, close the modal, then open it again.</p>");
+    const conf = {
+      height: 300,
+      menubar: false
+    };
+    return {
+      apiKey,
+      open,
+      content,
+      conf
+    };
+  }
+});
+</script>
+
+<style scoped>
+.demo-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+.demo-modal {
+  background: #fff;
+  padding: 1rem;
+  border-radius: 6px;
+  width: 720px;
+  max-width: 90vw;
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.3);
+}
+.demo-modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+.demo-modal-preview {
+  color: #555;
+  font-size: 0.85rem;
+  word-break: break-word;
+}
+</style>

--- a/src/main/ts/components/Editor.ts
+++ b/src/main/ts/components/Editor.ts
@@ -52,6 +52,12 @@ export const Editor = defineComponent({
     let mounting = true;
     const initialValue: string = props.initialValue ? props.initialValue : '';
     let cache = '';
+    // Recovery state for when the editor's iframe is moved in the DOM (see watchReattach).
+    let reattachIframe: HTMLIFrameElement | null = null;
+    let reattachHandler: (() => void) | null = null;
+    let reinitializing = false;
+    // False once the component is torn down, so a queued re-init can bail out.
+    let active = true;
 
     const getContent = (isMounting: boolean): () => string => modelBind ?
       () => (modelValue?.value ? modelValue.value : '') :
@@ -75,7 +81,19 @@ export const Editor = defineComponent({
             setMode(vueEditor, 'readonly');
           }
 
-          editor.on('init', (e: EditorEvent<any>) => initEditor(e, props, ctx, editor, modelValue, content));
+          editor.on('init', (e: EditorEvent<any>) => {
+            initEditor(e, props, ctx, editor, modelValue, content);
+            watchReattach();
+          });
+          if (!modelBind && !inlineEditor) {
+            // Remember the content as it changes so we can restore it after a re-init;
+            // the moved iframe is already blank by the time we notice. v-model uses
+            // modelValue, and inline editors have no iframe, so this is only for the
+            // uncontrolled initialValue case.
+            editor.on('change input undo redo SetContent', () => {
+              cache = editor.getContent();
+            });
+          }
           if (typeof conf.setup === 'function') {
             conf.setup(editor);
           }
@@ -86,6 +104,59 @@ export const Editor = defineComponent({
       }
       getTinymce().init(finalInit);
       mounting = false;
+    };
+    const removeReattachListener = (): void => {
+      if (reattachIframe !== null && reattachHandler !== null) {
+        reattachIframe.removeEventListener('load', reattachHandler);
+      }
+      reattachIframe = null;
+      reattachHandler = null;
+    };
+    const reinitializeEditor = (): void => {
+      if (vueEditor === null || reinitializing) {
+        return;
+      }
+      reinitializing = true;
+      // Don't read the editor here: its iframe is already blank. cache/modelValue hold the content.
+      removeReattachListener();
+      getTinymce()?.remove(vueEditor);
+      // The Vue docs state you can either use the callback form or await it. Ref: https://vuejs.org/api/general.html#nexttick
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      nextTick(() => {
+        try {
+          // Skip if the component was torn down while this was queued.
+          if (active) {
+            initWrapper();
+          }
+        } finally {
+          // Always clear the guard so a failed init doesn't disable recovery.
+          reinitializing = false;
+        }
+      });
+    };
+    // Recover when the editor's iframe is moved in the DOM, e.g. by a modal that
+    // relocates its content or by Vue re-ordering the surrounding elements. Moving an
+    // iframe blanks it, and Vue doesn't unmount the component, so nothing else fixes
+    // it. The iframe fires `load` again on each insertion, so a `load` after the first
+    // means it was moved and must be re-created. Inline editors have no iframe.
+    // See #131 and #230.
+    const watchReattach = (): void => {
+      removeReattachListener();
+      if (inlineEditor || vueEditor === null) {
+        return;
+      }
+      // iframeElement/removed are typed from v5 on; the null/falsy guards keep this safe on v4.
+      const iframe = vueEditor.iframeElement;
+      if (isNullOrUndefined(iframe)) {
+        return;
+      }
+      reattachIframe = iframe;
+      reattachHandler = () => {
+        if (vueEditor !== null && !vueEditor.removed && !reinitializing) {
+          reinitializeEditor();
+        }
+      };
+      iframe.addEventListener('load', reattachHandler);
     };
     watch(readonly, (isReadonly) => {
       if (vueEditor !== null) {
@@ -102,10 +173,11 @@ export const Editor = defineComponent({
       }
     });
     watch(tagName, (_) => {
-      if (vueEditor) {
+      if (vueEditor && !vueEditor.removed && !reinitializing) {
         if (!modelBind) {
           cache = vueEditor.getContent();
         }
+        removeReattachListener();
         getTinymce()?.remove(vueEditor);
         // The Vue docs state you can either use the callback form or await it. Ref: https://vuejs.org/api/general.html#nexttick
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
@@ -129,18 +201,23 @@ export const Editor = defineComponent({
       }
     });
     onBeforeUnmount(() => {
+      active = false;
+      removeReattachListener();
       if (getTinymce() !== null) {
         getTinymce().remove(vueEditor);
       }
     });
     if (!inlineEditor) {
       onActivated(() => {
+        active = true;
         if (!mounting) {
           initWrapper();
         }
       });
       onDeactivated(() => {
-        if (vueEditor) {
+        active = false;
+        removeReattachListener();
+        if (vueEditor && !vueEditor.removed) {
           if (!modelBind) {
             cache = vueEditor.getContent();
           }
@@ -151,6 +228,7 @@ export const Editor = defineComponent({
     const rerender = (init: EditorOptions) => {
       if (vueEditor) {
         cache = vueEditor.getContent();
+        removeReattachListener();
         getTinymce()?.remove(vueEditor);
         conf = { ...conf, ...init, ...defaultInitValues };
 

--- a/src/test/ts/browser/ReattachTest.ts
+++ b/src/test/ts/browser/ReattachTest.ts
@@ -1,0 +1,243 @@
+import { Assertions, Keyboard, Keys, Waiter } from '@ephox/agar';
+import { Arr } from '@ephox/katamari';
+import { SugarElement } from '@ephox/sugar';
+import { after, afterEach, before, context, describe, it } from '@ephox/bedrock-client';
+import { VersionLoader } from '@tinymce/miniature';
+import { getRoot, pRender, remove } from '../alien/Loader';
+import { cleanupGlobalTinymce } from '../alien/TestHelper';
+
+// Regression tests for https://github.com/tinymce/tinymce-vue/issues/131 and
+// https://github.com/tinymce/tinymce-vue/issues/230.
+//
+// When an iframe editor is moved in the DOM (for example by a modal that relocates
+// its content to <body> on open, or by Vue re-ordering the surrounding elements)
+// the browser discards and recreates the iframe's document, leaving the editor
+// blank and unresponsive. No Vue lifecycle hook fires for that move, so the
+// component has to recover on its own. These tests move the editor and assert that
+// it re-initializes and keeps its content.
+describe('Editor reattach (modal "zombie") recovery tests', () => {
+
+  // Move the node that hosts the editor (and therefore its iframe) under a new,
+  // still-connected parent. Per the HTML specification this re-runs the iframe's
+  // load steps, which is exactly what happens inside a modal.
+  const reparentEditor = (editor: any) => {
+    const mountPoint = editor.getElement().parentElement as HTMLElement;
+    const newParent = document.createElement('div');
+    getRoot().dom.appendChild(newParent);
+    newParent.appendChild(mountPoint);
+  };
+
+  Arr.each([ '4', '5', '6', '7', '8' ], (version) => {
+    context(`Version: ${version}`, () => {
+
+      before(async () => {
+        await VersionLoader.pLoadVersion(version);
+      });
+
+      after(() => {
+        cleanupGlobalTinymce();
+      });
+
+      afterEach(() => {
+        remove();
+      });
+
+      it('should re-initialize an iframe editor after it is detached and re-attached to the DOM', async () => {
+        const editors: any[] = [];
+        const vmContext = await pRender({
+          init: {
+            setup: (editor: any) => {
+              editors.push(editor);
+            }
+          }
+        }, `
+          <editor
+            :init="init"
+            license-key="gpl"
+          ></editor>`);
+
+        const firstEditor = vmContext.editor;
+        await Waiter.pTryUntil('The editor should be fully initialized', () => {
+          Assertions.assertEq('Editor is initialized', true, firstEditor.initialized);
+        });
+        Assertions.assertEq('Only one editor should exist before re-attaching', 1, editors.length);
+
+        firstEditor.setContent('<p>persisted content</p>');
+
+        reparentEditor(firstEditor);
+
+        await Waiter.pTryUntil('A new, fully initialized editor should be created after re-attaching', () => {
+          Assertions.assertEq('A second editor was created', true, editors.length >= 2);
+          Assertions.assertEq('The recovered editor is initialized', true, editors[editors.length - 1].initialized);
+        });
+
+        const recoveredEditor = editors[editors.length - 1];
+        Assertions.assertEq('The recovered editor is a new instance', false, recoveredEditor === firstEditor);
+        Assertions.assertEq('The original editor was removed', true, Boolean(firstEditor.removed));
+
+        const body = recoveredEditor.getBody();
+        Assertions.assertEq('The recovered editor has a body', true, Boolean(body));
+        Assertions.assertEq('The recovered editor body is connected to the document', true, body.isConnected);
+        Assertions.assertEq('The recovered editor body is editable', 'true', body.contentEditable);
+
+        Assertions.assertEq(
+          'Content is preserved across the recovery',
+          '<p>persisted content</p>',
+          recoveredEditor.getContent()
+        );
+      });
+
+      it('should keep recovering across repeated detach/re-attach cycles', async () => {
+        const editors: any[] = [];
+        const vmContext = await pRender({
+          init: {
+            setup: (editor: any) => {
+              editors.push(editor);
+            }
+          }
+        }, `
+          <editor
+            :init="init"
+            license-key="gpl"
+          ></editor>`);
+
+        await Waiter.pTryUntil('The editor should be fully initialized', () => {
+          Assertions.assertEq('Editor is initialized', true, vmContext.editor.initialized);
+        });
+        vmContext.editor.setContent('<p>round trip</p>');
+
+        for (let cycle = 1; cycle <= 3; cycle++) {
+          const priorCount = editors.length;
+          const current = editors[editors.length - 1];
+          reparentEditor(current);
+          await Waiter.pTryUntil(`A new, initialized editor should exist after cycle ${cycle}`, () => {
+            Assertions.assertEq('A new editor was created', true, editors.length > priorCount);
+            Assertions.assertEq('The newest editor is initialized', true, editors[editors.length - 1].initialized);
+          });
+          const recovered = editors[editors.length - 1];
+          Assertions.assertEq(`Cycle ${cycle}: editor body is editable`, 'true', recovered.getBody().contentEditable);
+          Assertions.assertEq(`Cycle ${cycle}: content is preserved`, '<p>round trip</p>', recovered.getContent());
+        }
+      });
+
+      it('should preserve v-model content and re-bind model handlers after re-attaching', async () => {
+        const editors: any[] = [];
+        const vmContext = await pRender({
+          content: '<p>model content</p>',
+          init: {
+            setup: (editor: any) => {
+              editors.push(editor);
+            }
+          }
+        }, `
+          <editor
+            :init="init"
+            license-key="gpl"
+            v-model="content"
+          ></editor>`);
+
+        const firstEditor = vmContext.editor;
+        await Waiter.pTryUntil('The editor should be fully initialized', () => {
+          Assertions.assertEq('Editor is initialized', true, firstEditor.initialized);
+        });
+        Assertions.assertEq('Editor starts with the v-model content', '<p>model content</p>', firstEditor.getContent());
+
+        reparentEditor(firstEditor);
+
+        await Waiter.pTryUntil('A new, fully initialized editor should be created after re-attaching', () => {
+          Assertions.assertEq('A second editor was created', true, editors.length >= 2);
+          Assertions.assertEq('The recovered editor is initialized', true, editors[editors.length - 1].initialized);
+        });
+
+        const recoveredEditor = editors[editors.length - 1];
+        Assertions.assertEq(
+          'The v-model content is preserved across the recovery',
+          '<p>model content</p>',
+          recoveredEditor.getContent()
+        );
+
+        // The model handlers must be re-bound on the recovered editor: an edit should
+        // still flow back out through `update:modelValue` to the bound data.
+        recoveredEditor.getBody().innerHTML = '<p>edited after recovery</p>';
+        Keyboard.keystroke(Keys.space(), {}, SugarElement.fromDom(recoveredEditor.getBody()) as SugarElement<Node>);
+        await Waiter.pTryUntil('Edits on the recovered editor update the v-model', () => {
+          Assertions.assertEq('The v-model reflects the recovered editor edit', '<p>edited after recovery</p>', vmContext.vm.content);
+        });
+      });
+
+      it('should recover when Vue moves the editor in the DOM by re-ordering siblings (#230)', async () => {
+        const editors: any[] = [];
+        const vmContext = await pRender({
+          content: '<p>kept across the move</p>',
+          items: [ 'editor', 'a', 'b' ],
+          init: {
+            setup: (editor: any) => {
+              editors.push(editor);
+            }
+          }
+        }, `
+          <div>
+            <template v-for="item in items" :key="item">
+              <div v-if="item === 'editor'"><editor :init="init" license-key="gpl" v-model="content"></editor></div>
+              <p v-else>{{ item }}</p>
+            </template>
+          </div>`);
+
+        const firstEditor = vmContext.editor;
+        await Waiter.pTryUntil('The editor should be fully initialized', () => {
+          Assertions.assertEq('Editor is initialized', true, firstEditor.initialized);
+        });
+
+        // Re-order the list so Vue moves the wrapper holding the editor (and its
+        // iframe) to a new position, which is what blanks the editor in #230.
+        vmContext.vm.items = [ 'a', 'b', 'editor' ];
+
+        await Waiter.pTryUntil('A new, fully initialized editor should be created after the move', () => {
+          Assertions.assertEq('A second editor was created', true, editors.length >= 2);
+          Assertions.assertEq('The recovered editor is initialized', true, editors[editors.length - 1].initialized);
+        });
+
+        const recoveredEditor = editors[editors.length - 1];
+        Assertions.assertEq('The recovered editor body is editable', 'true', recoveredEditor.getBody().contentEditable);
+        Assertions.assertEq(
+          'Content is preserved across the move',
+          '<p>kept across the move</p>',
+          recoveredEditor.getContent()
+        );
+      });
+
+      it('should not register reattach recovery for inline editors', async () => {
+        const editors: any[] = [];
+        const vmContext = await pRender({
+          init: {
+            setup: (editor: any) => {
+              editors.push(editor);
+            }
+          }
+        }, `
+          <editor
+            :init="init"
+            :inline="true"
+            license-key="gpl"
+          ></editor>`);
+
+        const firstEditor = vmContext.editor;
+        await Waiter.pTryUntil('The inline editor should be fully initialized', () => {
+          Assertions.assertEq('Editor is initialized', true, firstEditor.initialized);
+        });
+        // Structural guarantee: an inline editor has no iframe, so there is nothing for
+        // the browser to blank and no `load` listener is ever registered.
+        Assertions.assertEq('An inline editor has no iframe element', true, !firstEditor.iframeElement);
+
+        reparentEditor(firstEditor);
+
+        // Give any (incorrect) asynchronous re-init a chance to run before asserting
+        // that the inline editor instance is untouched.
+        await Waiter.pWait(100);
+        Assertions.assertEq('No additional editor should be created for an inline editor', 1, editors.length);
+        Assertions.assertEq('The inline editor is the same instance', true, vmContext.editor === firstEditor);
+        Assertions.assertEq('The inline editor was not removed', false, Boolean(firstEditor.removed));
+      });
+    });
+  });
+});


### PR DESCRIPTION
## What this fixes

Fixes #131 and #230, two reports of the same "blank editor" problem (also seen in #106 and #113).

The editor works the first time but comes back blank and unresponsive once something moves it in the DOM. Two common triggers:

- a modal or dialog that relocates its content on open (Bootstrap-Vue, Vuetify, and others do this), per #131;
- Vue re-ordering the elements around the editor, for example when sibling `v-if` blocks are toggled, per #230.

The cause is browser behavior, not TinyMCE. Per the HTML standard, removing an `<iframe>` from the document and inserting it again discards and recreates its document, so moving the editor wipes the editing iframe. Vue never unmounts the component during the move, so none of the lifecycle hooks fire and the editor has no chance to recover. SimonFc explained this back in #106; until now the only answer was a manual `v-if` or `:key` workaround in application code.

## How it works

The same part of the standard says an iframe re-runs its load steps every time it is inserted, so it fires a `load` event again on re-insertion. The component now listens for that. The first `load` is the editor's own initialization; any `load` after that means the iframe was moved and blanked. When it happens, the dead editor is removed and a new one is initialized in place, with its content restored.

A few specifics:

- Content is kept. For `v-model` it comes from the bound value. For the uncontrolled (`initialValue`) case the component keeps a copy of the content current as it changes, since the blanked iframe can no longer be read by the time we detect the move.
- Inline editors have no iframe, so nothing changes for them.
- The `load` listener is removed on every teardown path, and the re-init is guarded so it can't run after the component is unmounted or deactivated, and can't loop.

It is automatic. Existing apps need no changes, and normal and inline usage behave exactly as before.

## Tests

`src/test/ts/browser/ReattachTest.ts` moves the editor and checks that it recovers. It runs against TinyMCE 4 through 8 and covers:

- recovery and content preservation after a move (the modal case)
- repeated open/close cycles
- `v-model`: content preserved and the model handlers re-bound on the new editor
- Vue re-ordering a wrapper that holds the editor (the #230 case)
- inline editors registering no recovery

The full suite (62 tests) passes, and the library and demo both build.

## Demo

Added a `Modal` view to the demo app (route `/modal`) that reproduces the problem with a `Teleport`-based modal and shows the editor surviving repeated opens. It pulls in no extra dependencies.